### PR TITLE
build.tools can only have "python" section

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.11"
-    sphinx: "8.2.3" 
   commands:
     - pip install -r rpa/docs/requirements.txt  # For some reason, rtd doesn't install requirements.txt automatically
     - make -C rpa/docs html  # Use your Makefile to build docs


### PR DESCRIPTION
RTD error:
Config file validation error Config validation error in build.tools. Expected one of (python, nodejs, ruby, rust, golang), got type str (sphinx). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)