### PR TITLE
Fix SSBO binding index to avoid GL_INVALID_VALUE on limited-binding GPUs

### DIFF
--- a/rpa/open_rv/rpa_core/api/color_api_core.py
+++ b/rpa/open_rv/rpa_core/api/color_api_core.py
@@ -698,7 +698,10 @@ class ColorApiCore(QtCore.QObject):
         self.__ssbo = GL.glGenBuffers(1)
         GL.glBindBuffer(GL.GL_SHADER_STORAGE_BUFFER, self.__ssbo)
         GL.glBufferData(GL.GL_SHADER_STORAGE_BUFFER, len(data), bytes(data), GL.GL_STATIC_DRAW)
-        GL.glBindBufferBase(GL.GL_SHADER_STORAGE_BUFFER, 16, self.__ssbo)
+        # Check if binding point 16 is valid before binding
+        max_bindings = GL.glGetIntegerv(GL.GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS)
+        binding_index = min(16, max_bindings - 1)
+        GL.glBindBufferBase(GL.GL_SHADER_STORAGE_BUFFER, binding_index, self.__ssbo)
 
     def __get_source_resolution(self, source):
         smi = rvc.sourceMediaInfo(source)


### PR DESCRIPTION
### Summary
This patch addresses a `GL_INVALID_VALUE` error encountered in `color_api_core.py` when binding the SSBO at index 16 on GPUs that support only 16 binding points (valid indices 0–15).

### Problem
`GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS` returns the *count* of supported SSBO bindings, not the highest index. Binding to index 16 when the count is 16 causes OpenGL to throw `GL_INVALID_VALUE`.

### Resolution
The SSBO binding index is now computed dynamically:
```python
max_bindings = GL.glGetIntegerv(GL.GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS)
binding_index = min(16, max_bindings - 1)
GL.glBindBufferBase(GL.GL_SHADER_STORAGE_BUFFER, binding_index, self.__ssbo)

This ensures the index is always valid across all GPUs.

Verification
Tested on a system with GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS = 16. Now binding succeeds without error.
