### PR TITLE
Add rv-frame-compare mock plugin for deployment workflow testing

### DIFF
--- a/plugins/rv-frame-compare/README.md
+++ b/plugins/rv-frame-compare/README.md
@@ -1,0 +1,38 @@
+# RV Frame Compare
+
+Side-by-side frame comparison with wipe, difference, and overlay modes for OpenRV review sessions.
+
+- **Version**: 1.0.0
+- **Author**: test-contributor
+- **License**: Apache-2.0
+- **Host app**: OpenRV 2024.0+
+
+## Overview
+
+RV Frame Compare adds a dockable panel to OpenRV that lets reviewers compare any two frames or sources
+side-by-side without leaving the session. Three comparison modes are supported:
+
+- **Wipe** — drag a split line horizontally or vertically across the viewport
+- **Difference** — subtracts pixel values and amplifies the result for spotting subtle changes
+- **Overlay** — blends two sources at a configurable opacity
+
+## Installation
+
+1. Copy the `rv-frame-compare/` folder into your RV support path:
+   - **macOS**: `~/Library/Application Support/RV/Mu/`
+   - **Linux**: `~/.rv/Mu/`
+2. Restart OpenRV.
+3. Open **Preferences → Packages** and enable **RV Frame Compare**.
+
+## Usage
+
+1. Load two sources into your session.
+2. Open **View → Frame Compare** to dock the panel.
+3. Select sources A and B from the dropdowns.
+4. Choose a comparison mode from the toolbar.
+
+## Known Limitations
+
+- Difference mode requires both sources to have matching pixel dimensions.
+- Overlay opacity resets to 50% on session reload.
+- Not compatible with OpenRV stereo display mode.

--- a/plugins/rv-frame-compare/package.json
+++ b/plugins/rv-frame-compare/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "rv-frame-compare",
+  "version": "1.0.0",
+  "description": "Side-by-side frame comparison with wipe, difference, and overlay modes for OpenRV.",
+  "author": "test-contributor",
+  "license": "Apache-2.0",
+  "host_app": "OpenRV",
+  "min_host_version": "2024.0",
+  "tags": ["review", "utility", "workflow"],
+  "entry_point": "src/rv_frame_compare.py"
+}

--- a/plugins/rv-frame-compare/src/rv_frame_compare.py
+++ b/plugins/rv-frame-compare/src/rv_frame_compare.py
@@ -1,0 +1,62 @@
+"""
+RV Frame Compare — dockable side-by-side comparison panel for OpenRV.
+Supports wipe, difference, and overlay modes across two user-selected sources.
+"""
+
+import rv.commands as rvc
+import rv.rvtypes as rvt
+
+
+MODES = ("wipe", "difference", "overlay")
+
+
+class FrameComparePlugin(rvt.MinorMode):
+    def __init__(self):
+        rvt.MinorMode.__init__(self)
+        self._mode = "wipe"
+        self._source_a = None
+        self._source_b = None
+        self._opacity = 0.5
+        self._amplify = 1.0
+
+    def init(self, name, globalEventTable, localEventTable, menu):
+        rvt.MinorMode.init(
+            self,
+            name,
+            globalEventTable,
+            localEventTable,
+            menu,
+        )
+
+    def set_mode(self, mode: str):
+        if mode not in MODES:
+            raise ValueError(f"Unknown mode: {mode!r}. Choose from {MODES}")
+        self._mode = mode
+        self._apply()
+
+    def set_sources(self, source_a: str, source_b: str):
+        self._source_a = source_a
+        self._source_b = source_b
+        self._apply()
+
+    def set_opacity(self, value: float):
+        self._opacity = max(0.0, min(1.0, value))
+        self._apply()
+
+    def set_amplify(self, value: float):
+        self._amplify = max(0.1, value)
+        self._apply()
+
+    def _apply(self):
+        if not (self._source_a and self._source_b):
+            return
+        # Dispatch to OpenRV display pipeline — stub for test plugin
+        rvc.sendInternalEvent(
+            "frame-compare-update",
+            f"{self._mode}:{self._source_a}:{self._source_b}:"
+            f"{self._opacity}:{self._amplify}",
+        )
+
+
+def createMode():
+    return FrameComparePlugin()


### PR DESCRIPTION
## Summary

- Adds `plugins/rv-frame-compare/` with a README, `package.json` manifest, and a Python stub (`src/rv_frame_compare.py`)
- This is a test entry to validate that merging to `main` with a `plugins/**` change correctly fires the `trigger-registry-rebuild` workflow and triggers a site rebuild on `ori-shared-platform-website`

## Test plan

- [ ] Merge this PR to `main`
- [ ] Confirm the `Trigger Registry Rebuild` workflow runs in the Actions tab
- [ ] Confirm `ori-shared-platform-website` triggers a `deploy.yml` run immediately after

🤖 Generated with [Claude Code](https://claude.com/claude-code)