### PR TITLE
Enhance trigger workflow to auto-sync plugin registry content

### DIFF
--- a/.github/workflows/trigger-registry-rebuild.yml
+++ b/.github/workflows/trigger-registry-rebuild.yml
@@ -4,33 +4,100 @@
 #   at path: .github/workflows/trigger-registry-rebuild.yml
 #
 # PURPOSE:
-#   When a PR that touches the plugins/ directory is merged to main,
-#   this workflow fires a workflow_dispatch on ori-shared-platform-website
-#   so the registry site rebuilds immediately (rather than waiting for the
-#   daily scheduled rebuild at 06:00 UTC).
+#   When a PR that touches the plugins/ directory is merged to main:
+#     1. Syncs any changed plugin registry/ folders to the corresponding
+#        content/plugins/ directories in ori-shared-platform-website.
+#     2. Fires a workflow_dispatch on ori-shared-platform-website so the
+#        registry site rebuilds immediately.
+#
+#   Plugin authors only need to submit one PR to ori-shared-platform.
+#   Each plugin directory should include a registry/ subfolder:
+#
+#     plugins/my-plugin/
+#     ├── src/               ← plugin source code
+#     ├── README.md
+#     ├── package.json
+#     └── registry/
+#         ├── index.md       ← Hugo content page (frontmatter + docs)
+#         └── feature.svg    ← thumbnail shown on the registry card
 #
 # SETUP REQUIRED (one-time, by an org admin):
 #   1. Create a GitHub Fine-Grained Personal Access Token (PAT) with:
 #        - Repository access: ori-shared-platform-website
-#        - Permissions: Actions (read & write)
+#        - Permissions:
+#            Actions:  Read & write  (to dispatch deploy.yml)
+#            Contents: Read & write  (to push synced registry content)
 #   2. Add the token as a repository secret in ori-shared-platform:
 #        Settings → Secrets and variables → Actions → New repository secret
 #        Name:  REGISTRY_REBUILD_TOKEN
 #        Value: <the PAT>
+#
+# NOTE: Replace with a GitHub App when org admin access is available.
+#       A GitHub App token does not expire and is not tied to an individual.
+#       See: https://github.com/actions/create-github-app-token
 # ---------------------------------------------------------------------------
 
-name: Trigger Registry Rebuild
+name: Sync Plugin Registry & Trigger Rebuild
 
 on:
   push:
     branches: [main]
     paths:
-      - 'plugins/**'   # Only trigger when the plugins/ directory changes
+      - 'plugins/**'
 
 jobs:
-  trigger:
+  sync-and-rebuild:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout ori-shared-platform
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Needed to diff HEAD against its parent
+
+      - name: Sync changed registry/ folders to ori-shared-platform-website
+        env:
+          GH_TOKEN: ${{ secrets.REGISTRY_REBUILD_TOKEN }}
+        run: |
+          # Find plugins whose registry/ content changed in this push
+          changed_plugins=$(git diff --name-only HEAD~1 HEAD \
+            | grep '^plugins/.*/registry/' \
+            | sed 's|/registry/.*||' \
+            | sort -u)
+
+          if [ -z "$changed_plugins" ]; then
+            echo "No registry/ content changed — skipping sync"
+            exit 0
+          fi
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git clone \
+            https://x-access-token:${GH_TOKEN}@github.com/AcademySoftwareFoundation/ori-shared-platform-website.git \
+            /tmp/website
+
+          for plugin_path in $changed_plugins; do
+            plugin_name=$(basename "$plugin_path")
+            src="${plugin_path}/registry"
+            dst="/tmp/website/content/plugins/${plugin_name}"
+
+            if [ -d "$src" ]; then
+              mkdir -p "$dst"
+              cp -r "$src/." "$dst/"
+              echo "Synced: $plugin_name"
+            fi
+          done
+
+          cd /tmp/website
+          git add content/plugins/
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: sync plugin registry content from ori-shared-platform"
+            git push
+          fi
+
       - name: Dispatch rebuild to ori-shared-platform-website
         uses: actions/github-script@v8
         with:

--- a/plugins/rv-frame-compare/registry/feature.svg
+++ b/plugins/rv-frame-compare/registry/feature.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <defs>
+    <linearGradient id="bgLeft" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1f2e"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+    <linearGradient id="bgRight" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2a1a"/>
+      <stop offset="100%" stop-color="#0d1a0d"/>
+    </linearGradient>
+    <linearGradient id="wipeBar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4af0c8"/>
+      <stop offset="100%" stop-color="#2a8fa8"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Left panel (Source A) -->
+  <rect x="0" y="0" width="395" height="450" fill="url(#bgLeft)"/>
+
+  <!-- Film grain lines A -->
+  <rect x="40" y="60" width="315" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="90" width="200" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="120" width="260" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="150" width="180" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="180" width="280" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="210" width="220" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="240" width="300" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="270" width="160" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="300" width="240" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="330" width="200" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="360" width="280" height="2" fill="#2a3040" rx="1"/>
+
+  <!-- Render blocks (A — cold blue tones) -->
+  <rect x="60" y="70" width="120" height="80" rx="4" fill="#1e3a5c" opacity="0.8"/>
+  <rect x="200" y="70" width="140" height="80" rx="4" fill="#152d47" opacity="0.8"/>
+  <rect x="60" y="200" width="260" height="60" rx="4" fill="#1a3352" opacity="0.6"/>
+  <rect x="60" y="310" width="80" height="80" rx="4" fill="#1e3a5c" opacity="0.7"/>
+  <rect x="160" y="310" width="180" height="80" rx="4" fill="#152d47" opacity="0.6"/>
+
+  <!-- Label A -->
+  <rect x="16" y="16" width="60" height="22" rx="4" fill="#1e88e5" opacity="0.9"/>
+  <text x="46" y="31" font-family="monospace" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">SRC A</text>
+
+  <!-- Right panel (Source B) -->
+  <rect x="405" y="0" width="395" height="450" fill="url(#bgRight)"/>
+
+  <!-- Film grain lines B -->
+  <rect x="410" y="60" width="315" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="90" width="240" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="120" width="190" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="150" width="270" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="180" width="200" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="210" width="300" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="240" width="160" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="270" width="250" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="300" width="220" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="330" width="280" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="360" width="180" height="2" fill="#2a3828" rx="1"/>
+
+  <!-- Render blocks (B — warm green tones, slightly different layout) -->
+  <rect x="430" y="70" width="140" height="80" rx="4" fill="#1a3d1a" opacity="0.8"/>
+  <rect x="590" y="70" width="120" height="80" rx="4" fill="#163016" opacity="0.8"/>
+  <rect x="430" y="200" width="260" height="60" rx="4" fill="#1f3d1f" opacity="0.6"/>
+  <rect x="430" y="310" width="180" height="80" rx="4" fill="#1a3d1a" opacity="0.7"/>
+  <rect x="630" y="310" width="80" height="80" rx="4" fill="#163016" opacity="0.6"/>
+
+  <!-- Label B -->
+  <rect x="724" y="16" width="60" height="22" rx="4" fill="#43a047" opacity="0.9"/>
+  <text x="754" y="31" font-family="monospace" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">SRC B</text>
+
+  <!-- Wipe divider -->
+  <rect x="396" y="0" width="8" height="450" fill="url(#wipeBar)" opacity="0.95"/>
+
+  <!-- Wipe handle -->
+  <circle cx="400" cy="225" r="18" fill="#4af0c8" opacity="0.95"/>
+  <text x="400" y="231" font-family="monospace" font-size="16" fill="#0d1117" text-anchor="middle" font-weight="bold">⇔</text>
+
+  <!-- Mode pills -->
+  <rect x="270" y="408" width="70" height="26" rx="13" fill="#4af0c8" opacity="0.2"/>
+  <text x="305" y="425" font-family="monospace" font-size="11" fill="#4af0c8" text-anchor="middle">WIPE</text>
+
+  <rect x="350" y="408" width="90" height="26" rx="13" fill="#ffffff" opacity="0.06"/>
+  <text x="395" y="425" font-family="monospace" font-size="11" fill="#88a0a8" text-anchor="middle">DIFFERENCE</text>
+
+  <rect x="450" y="408" width="80" height="26" rx="13" fill="#ffffff" opacity="0.06"/>
+  <text x="490" y="425" font-family="monospace" font-size="11" fill="#88a0a8" text-anchor="middle">OVERLAY</text>
+
+  <!-- Title -->
+  <text x="400" y="390" font-family="monospace" font-size="13" fill="#4af0c8" text-anchor="middle" opacity="0.7">RV Frame Compare</text>
+</svg>

--- a/plugins/rv-frame-compare/registry/index.md
+++ b/plugins/rv-frame-compare/registry/index.md
@@ -1,0 +1,67 @@
++++
+title       = "RV Frame Compare"
+description = "Side-by-side frame comparison with wipe, difference, and overlay modes for OpenRV review sessions."
+date        = 2026-05-12T00:00:00Z
+draft       = false
+
+version = "1.0.0"
+author  = "test-contributor"
+license = "Apache-2.0"
+
+host_app = ["OpenRV"]
+tags     = ["review", "utility", "workflow"]
+
+[params]
+  repoPath = "plugins/rv-frame-compare"
++++
+
+## Overview
+
+RV Frame Compare adds a dockable panel to OpenRV that lets reviewers compare any two frames or sources
+side-by-side without leaving the session. Three comparison modes are supported:
+
+- **Wipe** — drag a split line horizontally or vertically across the viewport
+- **Difference** — subtracts pixel values and amplifies the result for easy spotting of subtle changes
+- **Overlay** — blends two sources at a configurable opacity
+
+This plugin was created as a test case for the ORI plugin registry deployment workflow.
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| OpenRV | 2024.0 or later |
+| Python | 3.9+ |
+| OS | macOS 12+, Linux (RHEL 8+) |
+
+## Installation
+
+### OpenRV
+
+1. Download the plugin package from the repository (see link above).
+2. Copy the `rv-frame-compare/` folder into your RV support path:
+   - **macOS**: `~/Library/Application Support/RV/Mu/`
+   - **Linux**: `~/.rv/Mu/`
+3. Restart OpenRV.
+4. Open **Preferences → Packages** and enable **RV Frame Compare**.
+
+### Verify
+
+After restarting, a **Frame Compare** panel should appear in the **View** menu.
+
+## Usage
+
+1. Load two sources into your session (e.g. a render and a reference plate).
+2. Open **View → Frame Compare** to dock the panel.
+3. Use the **A** and **B** dropdowns to select your two sources.
+4. Choose a comparison mode from the toolbar:
+   - **Wipe**: Click and drag the divider line in the viewport.
+   - **Difference**: Adjust the **Amplify** slider to increase contrast on subtle differences.
+   - **Overlay**: Use the **Opacity** slider to blend the two sources.
+5. Press **Reset** to return to single-source view.
+
+## Known Limitations
+
+- Difference mode does not support sources with mismatched resolutions; both inputs must be the same pixel dimensions.
+- Overlay mode opacity resets to 50% when the session is saved and reopened.
+- Not compatible with OpenRV stereo (3D) display mode.


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/trigger-registry-rebuild.yml` to a two-step workflow:
  1. **Sync** — detects which `plugins/*/registry/` folders changed and pushes them directly to `content/plugins/` in `ori-shared-platform-website`
  2. **Rebuild** — dispatches `deploy.yml` on `ori-shared-platform-website` as before
- Adds `plugins/rv-frame-compare/registry/` (index.md + feature.svg) to wire the existing test plugin into the new structure

## What this changes for plugin authors

Plugin submissions now only need **one PR to this repo**. Include a `registry/` subfolder alongside your source:

```
plugins/my-plugin/
├── src/
├── README.md
├── package.json
└── registry/
    ├── index.md      ← Hugo content page
    └── feature.svg   ← thumbnail
```

The workflow handles syncing to ori-shared-platform-website automatically on merge.

## PAT requirements

`REGISTRY_REBUILD_TOKEN` now needs `Contents: Read & write` on `ori-shared-platform-website` in addition to `Actions: Read & write`. This has been updated on the token.

## Test plan

- [ ] Merge this PR
- [ ] Confirm `Sync Plugin Registry & Trigger Rebuild` workflow runs in Actions
- [ ] Confirm a bot commit appears on `ori-shared-platform-website/content/plugins/rv-frame-compare/`
- [ ] Confirm `deploy.yml` runs on `ori-shared-platform-website`
- [ ] Confirm plugin card is visible at https://academysoftwarefoundation.github.io/ori-shared-platform-website/plugins/

🤖 Generated with [Claude Code](https://claude.com/claude-code)