### PR TITLE
Add rv-frame-compare registry entry (URL-only)

### DIFF
--- a/plugins/OpenRV/rv-frame-compare/feature.svg
+++ b/plugins/OpenRV/rv-frame-compare/feature.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <defs>
+    <linearGradient id="bgLeft" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1f2e"/>
+      <stop offset="100%" stop-color="#0d1117"/>
+    </linearGradient>
+    <linearGradient id="bgRight" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2a1a"/>
+      <stop offset="100%" stop-color="#0d1a0d"/>
+    </linearGradient>
+    <linearGradient id="wipeBar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4af0c8"/>
+      <stop offset="100%" stop-color="#2a8fa8"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Left panel (Source A) -->
+  <rect x="0" y="0" width="395" height="450" fill="url(#bgLeft)"/>
+
+  <!-- Film grain lines A -->
+  <rect x="40" y="60" width="315" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="90" width="200" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="120" width="260" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="150" width="180" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="180" width="280" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="210" width="220" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="240" width="300" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="270" width="160" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="300" width="240" height="2" fill="#2a3040" rx="1"/>
+  <rect x="40" y="330" width="200" height="2" fill="#1e2530" rx="1"/>
+  <rect x="40" y="360" width="280" height="2" fill="#2a3040" rx="1"/>
+
+  <!-- Render blocks (A — cold blue tones) -->
+  <rect x="60" y="70" width="120" height="80" rx="4" fill="#1e3a5c" opacity="0.8"/>
+  <rect x="200" y="70" width="140" height="80" rx="4" fill="#152d47" opacity="0.8"/>
+  <rect x="60" y="200" width="260" height="60" rx="4" fill="#1a3352" opacity="0.6"/>
+  <rect x="60" y="310" width="80" height="80" rx="4" fill="#1e3a5c" opacity="0.7"/>
+  <rect x="160" y="310" width="180" height="80" rx="4" fill="#152d47" opacity="0.6"/>
+
+  <!-- Label A -->
+  <rect x="16" y="16" width="60" height="22" rx="4" fill="#1e88e5" opacity="0.9"/>
+  <text x="46" y="31" font-family="monospace" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">SRC A</text>
+
+  <!-- Right panel (Source B) -->
+  <rect x="405" y="0" width="395" height="450" fill="url(#bgRight)"/>
+
+  <!-- Film grain lines B -->
+  <rect x="410" y="60" width="315" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="90" width="240" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="120" width="190" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="150" width="270" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="180" width="200" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="210" width="300" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="240" width="160" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="270" width="250" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="300" width="220" height="2" fill="#2a3828" rx="1"/>
+  <rect x="410" y="330" width="280" height="2" fill="#1e2e1c" rx="1"/>
+  <rect x="410" y="360" width="180" height="2" fill="#2a3828" rx="1"/>
+
+  <!-- Render blocks (B — warm green tones, slightly different layout) -->
+  <rect x="430" y="70" width="140" height="80" rx="4" fill="#1a3d1a" opacity="0.8"/>
+  <rect x="590" y="70" width="120" height="80" rx="4" fill="#163016" opacity="0.8"/>
+  <rect x="430" y="200" width="260" height="60" rx="4" fill="#1f3d1f" opacity="0.6"/>
+  <rect x="430" y="310" width="180" height="80" rx="4" fill="#1a3d1a" opacity="0.7"/>
+  <rect x="630" y="310" width="80" height="80" rx="4" fill="#163016" opacity="0.6"/>
+
+  <!-- Label B -->
+  <rect x="724" y="16" width="60" height="22" rx="4" fill="#43a047" opacity="0.9"/>
+  <text x="754" y="31" font-family="monospace" font-size="12" fill="#ffffff" text-anchor="middle" font-weight="bold">SRC B</text>
+
+  <!-- Wipe divider -->
+  <rect x="396" y="0" width="8" height="450" fill="url(#wipeBar)" opacity="0.95"/>
+
+  <!-- Wipe handle -->
+  <circle cx="400" cy="225" r="18" fill="#4af0c8" opacity="0.95"/>
+  <text x="400" y="231" font-family="monospace" font-size="16" fill="#0d1117" text-anchor="middle" font-weight="bold">⇔</text>
+
+  <!-- Mode pills -->
+  <rect x="270" y="408" width="70" height="26" rx="13" fill="#4af0c8" opacity="0.2"/>
+  <text x="305" y="425" font-family="monospace" font-size="11" fill="#4af0c8" text-anchor="middle">WIPE</text>
+
+  <rect x="350" y="408" width="90" height="26" rx="13" fill="#ffffff" opacity="0.06"/>
+  <text x="395" y="425" font-family="monospace" font-size="11" fill="#88a0a8" text-anchor="middle">DIFFERENCE</text>
+
+  <rect x="450" y="408" width="80" height="26" rx="13" fill="#ffffff" opacity="0.06"/>
+  <text x="490" y="425" font-family="monospace" font-size="11" fill="#88a0a8" text-anchor="middle">OVERLAY</text>
+
+  <!-- Title -->
+  <text x="400" y="390" font-family="monospace" font-size="13" fill="#4af0c8" text-anchor="middle" opacity="0.7">RV Frame Compare</text>
+</svg>

--- a/plugins/OpenRV/rv-frame-compare/index.md
+++ b/plugins/OpenRV/rv-frame-compare/index.md
@@ -1,0 +1,57 @@
++++
+title       = "RV Frame Compare"
+description = "Side-by-side frame comparison with wipe, difference, and overlay modes for OpenRV review sessions."
+date        = 2026-06-11T00:00:00Z
+draft       = false
+
+version = "1.0.0"
+author  = "erikstrauss"
+license = "Apache-2.0"
+
+host_app = ["OpenRV"]
+tags     = ["review", "utility", "workflow"]
+
+[params]
+  repoUrl   = "https://github.com/erikstrauss/rv-frame-compare"
+  repoOwner = "erikstrauss"
++++
+
+## Overview
+
+RV Frame Compare adds a dockable panel to OpenRV that lets reviewers compare any two frames or sources
+side-by-side without leaving the session. Three comparison modes are supported:
+
+- **Wipe** — drag a split line horizontally or vertically across the viewport
+- **Difference** — subtracts pixel values and amplifies the result for easy spotting of subtle changes
+- **Overlay** — blends two sources at a configurable opacity
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| OpenRV | 2024.0 or later |
+| Python | 3.9+ |
+| OS | macOS 12+, Linux (RHEL 8+) |
+
+## Installation
+
+1. Download or clone the plugin from the repository linked above.
+2. Copy the plugin folder into your RV support path:
+   - **macOS**: `~/Library/Application Support/RV/Mu/`
+   - **Linux**: `~/.rv/Mu/`
+3. Restart OpenRV.
+4. Open **Preferences → Packages** and enable **RV Frame Compare**.
+
+## Usage
+
+1. Load two sources into your session.
+2. Open **View → Frame Compare** to dock the panel.
+3. Use the **A** and **B** dropdowns to select your two sources.
+4. Choose a comparison mode from the toolbar.
+5. Press **Reset** to return to single-source view.
+
+## Known Limitations
+
+- Difference mode requires both sources to have matching pixel dimensions.
+- Overlay opacity resets to 50% on session reload.
+- Not compatible with OpenRV stereo display mode.


### PR DESCRIPTION
## Summary

- Adds URL-only registry entry for rv-frame-compare
- Plugin source lives at https://github.com/erikstrauss/rv-frame-compare
- `index.md` uses `repoUrl` and `repoOwner` schema (replaces old `repoPath`)
- Includes `feature.svg` thumbnail

Supersedes #48 (which had a conflict after #47 was merged).

## Test plan

- [ ] Verify `plugins/OpenRV/rv-frame-compare/` contains only `index.md` and `feature.svg`
- [ ] Confirm `repoUrl` points at `https://github.com/erikstrauss/rv-frame-compare`
- [ ] After merge, confirm the plugin card appears on the registry site within minutes

Signed-off-by: erikstrauss <erik.strauss@gmail.com>