### PR TITLE
Add xstudio-review-notes registry entry (URL-only)

### DIFF
--- a/plugins/xStudio/xstudio-review-notes/feature.svg
+++ b/plugins/xStudio/xstudio-review-notes/feature.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#0d0d1a"/>
+    </linearGradient>
+    <linearGradient id="panelGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#242438"/>
+      <stop offset="100%" stop-color="#1a1a2c"/>
+    </linearGradient>
+    <linearGradient id="btnGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c85aff"/>
+      <stop offset="100%" stop-color="#8a2be2"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="450" fill="url(#bg)"/>
+
+  <!-- Viewport (xStudio player area) -->
+  <rect x="0" y="0" width="540" height="450" fill="#0a0a14"/>
+
+  <!-- Film strip suggestion -->
+  <rect x="0" y="190" width="540" height="70" fill="#111122" opacity="0.6"/>
+  <rect x="20" y="200" width="70" height="50" rx="3" fill="#1e1e3a" opacity="0.8"/>
+  <rect x="100" y="200" width="70" height="50" rx="3" fill="#1e1e3a" opacity="0.8"/>
+  <rect x="180" y="200" width="70" height="50" rx="3" fill="#252540" opacity="0.8"/>
+  <rect x="260" y="200" width="70" height="50" rx="3" fill="#1e1e3a" opacity="0.8"/>
+  <rect x="340" y="200" width="70" height="50" rx="3" fill="#1e1e3a" opacity="0.8"/>
+  <rect x="420" y="200" width="70" height="50" rx="3" fill="#1e1e3a" opacity="0.8"/>
+
+  <!-- Active frame highlight -->
+  <rect x="178" y="198" width="74" height="54" rx="4" fill="none" stroke="#c85aff" stroke-width="2" opacity="0.9"/>
+
+  <!-- Annotation dot on viewport -->
+  <circle cx="310" cy="120" r="10" fill="#ff4444" opacity="0.85"/>
+  <line x1="320" y1="115" x2="370" y2="90" stroke="#ff4444" stroke-width="1.5" opacity="0.7"/>
+  <rect x="370" y="76" width="140" height="28" rx="4" fill="#2a1a1a" stroke="#ff4444" stroke-width="1" opacity="0.9"/>
+  <text x="378" y="94" font-family="monospace" font-size="10" fill="#ff8888">Fix sky grade — upper left</text>
+
+  <!-- Second annotation -->
+  <circle cx="180" cy="100" r="8" fill="#44aaff" opacity="0.85"/>
+  <line x1="188" y1="95" x2="220" y2="75" stroke="#44aaff" stroke-width="1.5" opacity="0.7"/>
+  <rect x="220" y="62" width="110" height="24" rx="4" fill="#1a1a2a" stroke="#44aaff" stroke-width="1" opacity="0.9"/>
+  <text x="228" y="78" font-family="monospace" font-size="10" fill="#88ccff">Check the horizon</text>
+
+  <!-- Timecode bar -->
+  <rect x="0" y="280" width="540" height="24" fill="#111120"/>
+  <text x="16" y="296" font-family="monospace" font-size="11" fill="#8888aa">00:00:43:10</text>
+  <rect x="140" y="288" width="260" height="4" rx="2" fill="#2a2a4a"/>
+  <rect x="140" y="288" width="80" height="4" rx="2" fill="#c85aff" opacity="0.8"/>
+
+  <!-- Panel -->
+  <rect x="540" y="0" width="260" height="450" fill="url(#panelGrad)"/>
+  <rect x="540" y="0" width="260" height="1" fill="#c85aff" opacity="0.4"/>
+
+  <!-- Panel header -->
+  <text x="556" y="28" font-family="monospace" font-size="13" fill="#c85aff" font-weight="bold">Notes Export</text>
+  <line x1="540" y1="40" x2="800" y2="40" stroke="#2a2a4a" stroke-width="1"/>
+
+  <!-- Format selector -->
+  <text x="556" y="64" font-family="monospace" font-size="11" fill="#8888aa">Format</text>
+  <rect x="556" y="72" width="70" height="26" rx="4" fill="#c85aff" opacity="0.2" stroke="#c85aff" stroke-width="1"/>
+  <text x="582" y="89" font-family="monospace" font-size="11" fill="#c85aff" text-anchor="middle">JSON</text>
+  <rect x="634" y="72" width="70" height="26" rx="4" fill="#1e1e38" stroke="#3a3a5a" stroke-width="1"/>
+  <text x="669" y="89" font-family="monospace" font-size="11" fill="#6666aa" text-anchor="middle">CSV</text>
+
+  <!-- Destination -->
+  <text x="556" y="122" font-family="monospace" font-size="11" fill="#8888aa">Output path</text>
+  <rect x="556" y="130" width="210" height="26" rx="4" fill="#111128" stroke="#3a3a5a" stroke-width="1"/>
+  <text x="564" y="147" font-family="monospace" font-size="10" fill="#6666aa">~/reviews/session_notes.json</text>
+
+  <!-- Note list -->
+  <text x="556" y="182" font-family="monospace" font-size="11" fill="#8888aa">Annotations  (3)</text>
+  <line x1="556" y1="190" x2="776" y2="190" stroke="#2a2a4a" stroke-width="1"/>
+
+  <!-- Note rows -->
+  <rect x="556" y="196" width="220" height="42" rx="3" fill="#1a1a30"/>
+  <circle cx="568" cy="211" r="5" fill="#ff4444" opacity="0.9"/>
+  <text x="580" y="209" font-family="monospace" font-size="10" fill="#ccccee">SH010 · f.1042</text>
+  <text x="580" y="222" font-family="monospace" font-size="9" fill="#8888aa">Fix sky grade — upper left</text>
+  <text x="568" y="233" font-family="monospace" font-size="9" fill="#555577">reviewer</text>
+
+  <rect x="556" y="244" width="220" height="42" rx="3" fill="#161628"/>
+  <circle cx="568" cy="259" r="5" fill="#44aaff" opacity="0.9"/>
+  <text x="580" y="257" font-family="monospace" font-size="10" fill="#ccccee">SH010 · f.988</text>
+  <text x="580" y="270" font-family="monospace" font-size="9" fill="#8888aa">Check the horizon line</text>
+  <text x="568" y="281" font-family="monospace" font-size="9" fill="#555577">reviewer</text>
+
+  <rect x="556" y="292" width="220" height="42" rx="3" fill="#1a1a30"/>
+  <circle cx="568" cy="307" r="5" fill="#ffcc44" opacity="0.9"/>
+  <text x="580" y="305" font-family="monospace" font-size="10" fill="#ccccee">SH020 · f.2210</text>
+  <text x="580" y="318" font-family="monospace" font-size="9" fill="#8888aa">Motion blur too strong</text>
+  <text x="568" y="329" font-family="monospace" font-size="9" fill="#555577">reviewer</text>
+
+  <!-- Export button -->
+  <rect x="556" y="390" width="220" height="36" rx="6" fill="url(#btnGrad)"/>
+  <text x="666" y="413" font-family="monospace" font-size="13" fill="#ffffff" text-anchor="middle" font-weight="bold">Export</text>
+
+  <!-- Title -->
+  <text x="666" y="440" font-family="monospace" font-size="11" fill="#c85aff" text-anchor="middle" opacity="0.6">xStudio Review Notes Exporter</text>
+</svg>

--- a/plugins/xStudio/xstudio-review-notes/index.md
+++ b/plugins/xStudio/xstudio-review-notes/index.md
@@ -1,0 +1,76 @@
++++
+title       = "xStudio Review Notes Exporter"
+description = "Export reviewer annotations and session notes from xStudio to JSON or CSV for downstream pipeline consumption."
+date        = 2026-06-11T00:00:00Z
+draft       = false
+
+version = "1.0.0"
+author  = "erikstrauss"
+license = "Apache-2.0"
+
+host_app = ["xStudio"]
+tags     = ["annotation", "export", "pipeline", "workflow"]
+
+[params]
+  repoUrl   = "https://github.com/erikstrauss/xstudio-review-notes"
+  repoOwner = "erikstrauss"
++++
+
+## Overview
+
+xStudio Review Notes Exporter adds a panel to xStudio that collects all annotations,
+drawn notes, and text comments from a review session and exports them to a structured
+file for use in downstream pipeline tools.
+
+Supported output formats:
+
+- **JSON** — structured per-shot, per-frame annotation data
+- **CSV** — flat spreadsheet-friendly format for editorial and production tracking
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| xStudio | 1.2.0 or later |
+| Python | 3.9+ |
+| OS | macOS 12+, Linux (RHEL 8+) |
+
+## Installation
+
+1. Download or clone the plugin from the repository linked above.
+2. Copy the plugin folder into your xStudio plugin path:
+   - **macOS**: `~/Library/Application Support/xStudio/plugins/`
+   - **Linux**: `~/.xstudio/plugins/`
+3. Restart xStudio.
+4. Open **Preferences → Plugins** and enable **Review Notes Exporter**.
+
+## Usage
+
+1. Complete your review session and add annotations as normal.
+2. Open **Tools → Notes Export**.
+3. Choose an output format (JSON or CSV) and a destination path.
+4. Click **Export** — a file is written containing all annotations for the current session.
+
+### JSON output example
+
+```json
+{
+  "session": "review_2026-06-11",
+  "shots": [
+    {
+      "name": "SH010",
+      "frame": 1042,
+      "timecode": "00:00:43:10",
+      "author": "reviewer",
+      "note": "Fix the sky grade in the upper left corner.",
+      "color": "#ff4444"
+    }
+  ]
+}
+```
+
+## Known Limitations
+
+- Drawn (freehand) annotations are exported as bounding-box coordinates only, not vector paths.
+- CSV export does not preserve annotation colour data.
+- Exporting sessions with more than 5,000 annotations may be slow on first run.


### PR DESCRIPTION
## Summary

- Adds URL-only registry entry for xstudio-review-notes
- Plugin source lives at https://github.com/erikstrauss/xstudio-review-notes
- `index.md` uses `repoUrl` and `repoOwner` schema (replaces old `repoPath`)
- Includes `feature.svg` thumbnail

Supersedes #51. Branched from main after #50 merged to avoid update conflicts.

## Test plan

- [ ] Verify `plugins/xStudio/xstudio-review-notes/` contains only `index.md` and `feature.svg`
- [ ] Confirm `repoUrl` points at `https://github.com/erikstrauss/xstudio-review-notes`
- [ ] After merge, confirm the plugin card appears on the registry site within minutes

Signed-off-by: erikstrauss <erik.strauss@gmail.com>