### PR TITLE
Add CODEOWNERS for plugin directory ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# CODEOWNERS — Open Review Plugin Registry
+#
+# Plugin submitters are listed as owners of their own directory.
+# When a PR touches a plugin directory, GitHub automatically requests
+# a review from the listed owner(s).
+#
+# ENFORCEMENT NOTE (pending org admin action):
+#   CODEOWNERS review requests are advisory by default. To require plugin
+#   owners to approve changes to their own listings, a repo admin must enable:
+#     Settings > Branches > Branch protection rule for main
+#     ☑ Require review from Code Owners
+#
+# GLOBAL FALLBACK:
+#   Replace the team slug below with the actual ASWF GitHub team for
+#   ori-shared-platform committers. Until then, committer review is
+#   enforced only by convention.
+#
+# * @AcademySoftwareFoundation/ori-shared-platform-committers
+
+# ── OpenRV plugins ────────────────────────────────────────────────────────────
+/plugins/OpenRV/rv-frame-compare/          @erikstrauss
+
+# ── xStudio plugins ───────────────────────────────────────────────────────────
+/plugins/xStudio/xstudio-review-notes/     @erikstrauss


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` mapping each plugin directory to its submitter
- GitHub will automatically request the plugin owner's review on any PR touching their directory
- Global committer fallback team is documented but commented out (team slug TBD)

## Admin action required

CODEOWNERS review requests are advisory until a repo admin enables:

> Settings → Branches → Branch protection rule for `main` → **Require review from Code Owners**

This is documented in the CODEOWNERS file as a TODO.

## Test plan

- [ ] Open a test PR modifying `plugins/OpenRV/rv-frame-compare/` and confirm `@erikstrauss` is auto-requested as reviewer

Signed-off-by: erikstrauss <erik.strauss@gmail.com>