### PR TITLE
chore: remove stale CODEOWNERS entries and test artifact

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 #     Settings > Branches > Branch protection rule for main
 #     ☑ Require review from Code Owners
 #
-# GLOBAL FALLBACK:
+# GLOBAL FALLBACK (tracked in issue #61):
 #   Replace the team slug below with the actual ASWF GitHub team for
 #   ori-shared-platform committers. Until then, committer review is
 #   enforced only by convention.
@@ -18,7 +18,5 @@
 # * @AcademySoftwareFoundation/ori-shared-platform-committers
 
 # ── OpenRV plugins ────────────────────────────────────────────────────────────
-/plugins/OpenRV/rv-frame-compare/          @erikstrauss
+/plugins/OpenRV/filesystem_browser/        @richardssam
 
-# ── xStudio plugins ───────────────────────────────────────────────────────────
-/plugins/xStudio/xstudio-review-notes/     @erikstrauss

--- a/plugins/test_commit.json
+++ b/plugins/test_commit.json
@@ -1,2 +1,0 @@
-a test to see if the rebuild workflow for the website triggers on merge per the actions file
-testing this workflow trigger again on may 12 2026


### PR DESCRIPTION
## Changes

- **CODEOWNERS**: remove `rv-frame-compare` and `xstudio-review-notes` entries (plugin directories deleted in PR #58); add `filesystem_browser` entry owned by `@richardssam`; add `#61` reference for the pending global committer team slug
- **`plugins/test_commit.json`**: delete leftover CI test artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)