### PR TITLE
chore: registry cleanup — CODEOWNERS, README, CONTRIBUTING, test artifact

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,13 @@
 # When a PR touches a plugin directory, GitHub automatically requests
 # a review from the listed owner(s).
 #
-# ENFORCEMENT NOTE (pending org admin action):
+# ENFORCEMENT NOTE (pending org admin action — tracked in issue #62):
 #   CODEOWNERS review requests are advisory by default. To require plugin
 #   owners to approve changes to their own listings, a repo admin must enable:
 #     Settings > Branches > Branch protection rule for main
 #     ☑ Require review from Code Owners
 #
-# GLOBAL FALLBACK:
+# GLOBAL FALLBACK (tracked in issue #62):
 #   Replace the team slug below with the actual ASWF GitHub team for
 #   ori-shared-platform committers. Until then, committer review is
 #   enforced only by convention.
@@ -18,7 +18,5 @@
 # * @AcademySoftwareFoundation/ori-shared-platform-committers
 
 # ── OpenRV plugins ────────────────────────────────────────────────────────────
-/plugins/OpenRV/rv-frame-compare/          @erikstrauss
+/plugins/OpenRV/filesystem_browser/        @richardssam
 
-# ── xStudio plugins ───────────────────────────────────────────────────────────
-/plugins/xStudio/xstudio-review-notes/     @erikstrauss

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-Contributing to review_plugin_api
-=================================
+Contributing to ori-shared-platform
+=====================================
 
-Code contributions to review_plugin_api are always welcome.  Please review this document 
+Code contributions to ori-shared-platform are always welcome. Please review this document 
 to get a briefing on our process.
 
 
@@ -17,7 +17,7 @@ working groups).
 How to Ask for Help
 -------------------
 
-If you have trouble installing, building, or using review_plugin_api, but there's
+If you have trouble installing, building, or using ori-shared-platform, but there's
 not yet a solid reason to suspect you've encountered a genuine bug, start by
 posting a question at the slack channel above.
 
@@ -51,25 +51,6 @@ safety, as it prevents any possible future disputes between code authors and
 their employers or anyone else who might think they might own the IP output of
 the author.
 
-* [Corporate CLA](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/ASWF/CLA-corporate.md) :
-  If you are writing the code as part of your job, or if there is any
-  possibility that your employers might think they own any intellectual
-  property you create. This needs to be executed by someone who has
-  signatory power for the company.
-
-* [Individual CLA](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/ASWF/CLA-individual.md) :
-  If you are an individual writing the code on your own time, using your own
-  equipment, and you're SURE you are the sole owner of any intellectual
-  property you contribute.
-
-Please note that it is extremely common (nearly ubiquitous in the US and
-Canada, and maybe other places) for full-time employees of technology and
-entertainment companies to have IP clauses in their employment agreement (in
-that pile of paperwork you sign on your first day of work and then promptly
-forget about) that give the company rights to any code you write, even on your
-own time. The OpenImageIO project expects you to know and follow the rules of
-your employer and to have them sign a corporate CLA if necessary.
-
 The easiest way to sign CLAs is digitally [using
 EasyCLA](https://corporate.v1.easycla.lfx.linuxfoundation.org). There are
 detailed step-by-step instructions about using the EasyCLA system for
@@ -85,16 +66,11 @@ individual employees of the company who are authorized to submit pull
 requests, without needing to get an executive to amend and sign the agreement
 each time.
 
-Please note that these CLAs are based on the Apache 2.0 CLAs, and differ
-minimally, only as much as was required to correctly describe the EasyCLA
-process and our use of a CLA manager.
-
 **Contribution sign off**
 
-This project requires the use of the [Developer’s Certificate of Origin 1.1
+This project requires the use of the [Developer's Certificate of Origin 1.1
 (DCO)](https://developercertificate.org/), which is the same mechanism that
-the [Linux®
-Kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst#n416)
+the [Linux® Kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst#n416)
 and many other communities use to manage code contributions. The DCO is
 considered one of the simplest tools for sign offs from contributors as the
 representations are meant to be easy to read and indicating signoff is done
@@ -106,46 +82,20 @@ accepts the DCO:
     Signed-off-by: John Doe <john.doe@example.com>
 
 You can include this automatically when you commit a change to your local
-git repository using `git commit -s`. You might also want to
-leverage this [command line tool](https://github.com/coderanger/dco) for
-automatically adding the signoff message on commits.
+git repository using `git commit -s`.
 
 
 Commit messages
 ---------------
 
-### Summary heuristic
-
 Look at the commit history of the project to get a sense of the style and
 level of detail that is expected in commit messages.
 
-### General guidelines and expectations
-
 The first line of the commit message should be a short (less than 80
-characters) summary of the change, prefixed with the general nature of the
-change (see below).
+characters) summary of the change. The rest should explain why the change is
+necessary, describe any user- or developer-facing behaviour changes, and note
+any non-obvious implementation decisions.
 
-The rest of the commit message should be a more detailed explanation of the
-changes. Some commits are self-explanatory and don't need more than the
-summary line. Others may need a more detailed explanation. Hallmarks of
-a good commit message include:
-
-* An explanation of why the change is necessary and what you hope to
-  accomplish with it.
-* A description of any major user- or developer-facing changes that people
-  should be aware of: changes in APIs or behaviors, new features, etc.
-* An explanation of any tricky implementation details or design decisions that
-  might not be immediately obvious to someone reading the code.
-* Guideposts for somebody reviewing the code to understand the rationale and
-  have any supporting background information to fully understanding the code
-  changes.
-
-Remember that at some point in the future, a developer unfamiliar with your
-change (maybe you, long after you've forgotten the details) might need to
-understand or fix your patch. Keep that person in mind as your audience and
-strive to write a commit message that explains the context in a way that saves
-them time and effort. Be the hero in the story of their future debugging
-effort!
 
 Pull Requests and Code Review
 -----------------------------
@@ -156,35 +106,32 @@ The best way to submit changes is via GitHub Pull Request. GitHub has a
 All code must be formally reviewed before being merged into the official
 repository. The protocol is like this:
 
-1. Get a GitHub account, fork AcademySoftwareFoundation/OpenImageIO to create
-your own repository on GitHub, and then clone it to get a repository on your
-local machine.
+1. Fork AcademySoftwareFoundation/ori-shared-platform to create your own
+repository on GitHub, then clone it to get a repository on your local machine.
 
-1. Edit, compile, and test your changes. Run clang-format (see the
-instructions on coding style below).
+1. Edit, compile, and test your changes.
 
 1. Push your changes to your fork (each unrelated pull request to a separate
 "topic branch", please).
 
 1. Make a "pull request" on GitHub for your patch.
 
-2. If your patch will induce a major compatibility break, or has a design
-component that deserves extended discussion or debate among the wider OIIO
-community, then it may be prudent to email oiio-dev pointing everybody to
-the pull request URL and discussing any issues you think are important.
-
 1. All pull requests automatically launch CI jobs on GitHub Actions to
-ensure that the build completes and that the tests suite runs correctly, for
-a variety of platform, compiler, library, and flag combinations. The status
-of the CI tests for your PR will be displayed on the GitHub PR page. We will
-not accept PRs that don't build cleanly or pass the existing testsuite.
+ensure that the build completes and that the test suite runs correctly.
+We will not accept PRs that don't build cleanly or pass the existing test suite.
 
-1. The reviewer will look over the code and critique on the "comments" area.
-Reviewers may ask for changes, explain problems they found, congratulate the
-author on a clever solution, etc. But until somebody says "LGTM" (looks good
-to me), the code should not be committed. Sometimes this takes a few rounds
-of give and take. Please don't take it hard if your first try is not
-accepted. It happens to all of us.
+1. The reviewer will look over the code and leave comments. Reviewers may ask
+for changes or clarifications. Until somebody approves the PR, the code should
+not be committed.
 
-1. After approval, one of the senior developers (with commit approval to the
-official main repository) will merge your fixes into the master branch.
+1. After approval, a committer will merge your changes into the main branch.
+
+
+Plugin Registry Submissions
+----------------------------
+
+To add your plugin to the Open Review Plugin Registry, see the
+[Acceptance Criteria](./ACCEPTANCE-CRITERIA.md) for eligibility requirements,
+then follow the step-by-step [submission guide](https://academysoftwarefoundation.github.io/ori-shared-platform-website/contributing/).
+
+Plugin listing questions: [plugins@openreviewinitiative.org](mailto:plugins@openreviewinitiative.org)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Here you will find a growing collection of code meant to be leveraged across our
 
 Currently in this repository:
 
+## Open Review Plugin Registry
+
+A community index of plugins for [OpenRV](https://github.com/AcademySoftwareFoundation/OpenRV) and [xStudio](https://github.com/AcademySoftwareFoundation/xstudio). Plugin entries live under `plugins/` and are published automatically to the [registry website](https://academysoftwarefoundation.github.io/ori-shared-platform-website/).
+
+- **Browse plugins** — [registry website](https://academysoftwarefoundation.github.io/ori-shared-platform-website/plugins/)
+- **Submit a plugin** — see [ACCEPTANCE-CRITERIA.md](./ACCEPTANCE-CRITERIA.md) for eligibility, then follow the [submission guide](https://academysoftwarefoundation.github.io/ori-shared-platform-website/contributing/)
+- **Report a listing issue** — [open a GitHub Issue](https://github.com/AcademySoftwareFoundation/ori-shared-platform/issues) or email [plugins@openreviewinitiative.org](mailto:plugins@openreviewinitiative.org)
+
 ## RPA (Review Plugin API)
 
 To empower VFX and Animation studios to use their custom built review workflows and tools across any review-playback system (such as OpenRV or xStudio), RPA provides a unified collection of API modules and widgets.

--- a/plugins/test_commit.json
+++ b/plugins/test_commit.json
@@ -1,2 +1,0 @@
-a test to see if the rebuild workflow for the website triggers on merge per the actions file
-testing this workflow trigger again on may 12 2026


### PR DESCRIPTION
## Changes

**CODEOWNERS**
- Remove stale `rv-frame-compare` and `xstudio-review-notes` entries (directories deleted in PR #58)
- Add `filesystem_browser` entry owned by `@richardssam`
- Add `#62` reference for pending global committer team slug

**README**
- Add Open Review Plugin Registry section with links to the browse page, submission guide, `ACCEPTANCE-CRITERIA.md`, and plugin email

**CONTRIBUTING.md**
- Remove OpenImageIO-specific references: CLA links pointing to the OIIO repo, `oiio-dev` mailing list, `clang-format`, OIIO fork step, OIIO community mentions
- Update project name and GitHub URLs throughout
- Preserve overall structure for RPA code contributions
- Add Plugin Registry Submissions section pointing to `ACCEPTANCE-CRITERIA.md` and the hosted submission guide

**`plugins/test_commit.json`**
- Delete leftover CI test artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)